### PR TITLE
[Fix] 빌드 에러

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.yodel.youngsuni"
-    compileSdk 34
+    compileSdk 35
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -46,7 +46,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
발생한 에러
```dart
ERROR: R8: java.lang.IllegalArgumentException: Provided Metadata instance has version 2.1.0, while maximum supported version is 2.0.0. To support newer versions, update the kotlinx-metadata-jvm library.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:minifyReleaseWithR8'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.R8Task$R8Runnable
   > Compilation failed to complete
```

#### 원인
- Kotlin 2.1.0은 새로운 메타데이터 포맷(버전 2.1.0)을 사용
- 그런데 R8은 아직 메타데이터 v2.0.0까지만 지원
- 그래서 minifyReleaseWithR8 (릴리즈 빌드의 코드 난독화, 최적화 단계)에서 충돌이 발생한 것

#### 해결
- Kotlin 2.1.0 대신 1.9.10 또는 1.8.10을 사용하면 메타데이터 버전도 낮아지기 때문에 R8이 문제 없이 작동